### PR TITLE
[소재희] Feature/startup list

### DIFF
--- a/src/api/StartupService.js
+++ b/src/api/StartupService.js
@@ -1,0 +1,32 @@
+const STARTUP_API_BASE_URL = 'http://localhost:3000/api/startups';
+
+// Article 목록 가져오기
+export async function getStartupList(
+  page = 1,
+  limit = 10,
+  order = 'simInvest',
+  sort = 'desc',
+  keyword = ''
+) {
+  try {
+    const params = new URLSearchParams({
+      page,
+      limit,
+      order,
+      sort,
+      keyword,
+    });
+    const response = await fetch(
+      `${STARTUP_API_BASE_URL}?${params.toString()}`
+    );
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      console.log('errMessage', errorMessage);
+      throw new Error(`Error: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.log(error.message);
+    throw error;
+  }
+}

--- a/src/components/Startup/StartupDropdown.js
+++ b/src/components/Startup/StartupDropdown.js
@@ -1,0 +1,9 @@
+import styles from './StartupDropdown.module.css';
+
+export default function StartupDropdown() {
+  return (
+    <div className={styles.menu}>
+      <span>드롭 다운 메뉴</span>
+    </div>
+  );
+}

--- a/src/components/Startup/StartupDropdown.module.css
+++ b/src/components/Startup/StartupDropdown.module.css
@@ -1,0 +1,19 @@
+.menu {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 26.4rem;
+
+  padding: 1.2rem 1.6rem;
+
+  border: 0.1rem solid var(--secondary-gray-200);
+  border-radius: 1rem;
+}
+
+.menu span {
+  color: #D8D8D8;
+  font-size: 1.4rem;
+  font-weight: 400;
+  line-height: 1.7rem;
+}

--- a/src/components/Startup/StartupHeader.js
+++ b/src/components/Startup/StartupHeader.js
@@ -1,0 +1,11 @@
+import StartupDropdown from './StartupDropdown';
+import styles from './StartupHeader.module.css';
+
+export default function StartupHeader() {
+  return (
+    <div className={styles.header}>
+      <h1>전체 스타트업 목록</h1>
+      <StartupDropdown />
+    </div>
+  )
+}

--- a/src/components/Startup/StartupHeader.module.css
+++ b/src/components/Startup/StartupHeader.module.css
@@ -1,0 +1,12 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h1 {
+  color: white;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 2.4rem;
+}

--- a/src/components/Startup/StartupList.js
+++ b/src/components/Startup/StartupList.js
@@ -1,0 +1,67 @@
+//import { useState } from 'react';
+import styles from './StartupList.module.css';
+import useFetchStartups from '../../hooks/useFetchStartups';
+
+export default function StartupList() {
+  const MAX_ITEMS = 10;
+
+  const maxItems = MAX_ITEMS;
+  //const [searchKeyword, setSeacrchKeyword] = useState('');
+
+  const {
+    startups,
+    error,
+    //order,
+    //setOrder,
+    //sort,
+    //setSort,
+    currentPage,
+    //setCurrentPage,
+    //totoalCount,
+    //setSearch,
+    showLoading,
+  } = useFetchStartups(1, maxItems, 'total_investment', 'desc');
+
+  //const totalPages = Math.ceil(totoalCount / maxItems);
+
+  if (error) {
+    return <div className='error-message'>{error}</div>;
+  }
+  return (
+    <div>
+      <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>순위</th>
+          <th>기업명</th>
+          <th>기업소개</th>
+          <th>카테고리</th>
+          <th>누적 투자 금액</th>
+          <th>매출액</th>
+          <th>고용 인원</th>
+        </tr>
+      </thead>
+      <tbody>
+      { showLoading ? (
+        <tr>
+          <td colSpan="7">목록을 불러오는 중입니다....</td>
+        </tr>
+      ) : (
+      startups.map((startup, index) => (
+        <tr key={startup.id}>
+          <td>{index += 1 + (currentPage -1) * MAX_ITEMS}위</td>
+          <td>{startup.name}</td>
+          <td>{startup.description}</td>
+          <td>{startup.categoryId}</td>
+          <td>{startup.simInvest}</td>
+          <td>{startup.revenue}</td>
+          <td>{startup.employees}</td>          
+        </tr>
+        ))
+
+      )}
+      </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/Startup/StartupList.js
+++ b/src/components/Startup/StartupList.js
@@ -28,17 +28,17 @@ export default function StartupList() {
     return <div className='error-message'>{error}</div>;
   }
   return (
-    <div>
+    <div style={{ width: '100%', overflowX: 'auto' }}>
       <table className={styles.table}>
       <thead>
         <tr>
-          <th>순위</th>
-          <th>기업명</th>
-          <th>기업소개</th>
-          <th>카테고리</th>
-          <th>누적 투자 금액</th>
-          <th>매출액</th>
-          <th>고용 인원</th>
+          <th style={{ width: '6.8rem' }}>순위</th>
+          <th style={{ width: '21.3rem' }}>기업명</th>
+          <th style={{ width: '30.4rem' }}>기업소개</th>
+          <th style={{ width: '15.4rem' }}>카테고리</th>
+          <th style={{ width: '15.4rem' }}>누적 투자 금액</th>
+          <th style={{ width: '15.4rem' }}>매출액</th>
+          <th style={{ width: '15.4rem' }}>고용 인원</th>
         </tr>
       </thead>
       <tbody>
@@ -49,9 +49,22 @@ export default function StartupList() {
       ) : (
       startups.map((startup, index) => (
         <tr key={startup.id}>
-          <td>{index += 1 + (currentPage -1) * MAX_ITEMS}위</td>
-          <td>{startup.name}</td>
-          <td>{startup.description}</td>
+          <td>{index + 1 + (currentPage -1) * MAX_ITEMS}위</td>
+
+          <td style={{ textAlign: 'left' }}>
+            <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>
+              <img 
+              src={startup.image} 
+              alt={startup.name + ' 로고'} 
+              style={{ width: '3.2rem', height: '3.2rem', marginRight: '0.8rem', verticalAlign: 'middle' }} 
+              />
+            </span>
+            <span style={{ display: 'inline-block', verticalAlign: 'middle' }}>
+              {startup.name}
+            </span>
+          </td>
+
+          <td className={styles.description}>{startup.description}</td>
           <td>{startup.categoryId}</td>
           <td>{startup.simInvest}</td>
           <td>{startup.revenue}</td>

--- a/src/components/Startup/StartupList.module.css
+++ b/src/components/Startup/StartupList.module.css
@@ -1,6 +1,6 @@
 .table {
   width: 100%;
-
+  min-width: 80rem; /* 최소 너비 설정 추가 */
   margin-top: 1.6rem;
   border-radius: 0.25rem;
 
@@ -46,4 +46,27 @@
 
 .table tbody tr:not(:last-child) {
   border-bottom: 0.1rem solid var(--secondary-gray-300);
+}
+
+/* 추가 */
+.table-container {
+  width: 100%;
+  overflow-x: auto; /* 수평 스크롤 생성 */
+}
+
+
+.table td.description {
+  max-width: 30.4rem; /* 기본적으로 최대 너비를 차지함 */
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 두 줄까지만 허용 */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 1.5rem;
+  max-height: 4.7rem;   /* 두 줄 높이만큼 설정 (line-height * 2) + padding 값 */
+  line-height: 1.7rem;  /* 줄 높이를 설정 */
+  text-align: left; 
+
+  /* 표준 line-clamp 속성을 추가 : VS Code에서 경고문구 제거를 위해 */
+  line-clamp: 2; /* 표준 속성으로 정의하지만 아직 대부분의 브라우저에서 미지원 */
 }

--- a/src/components/Startup/StartupList.module.css
+++ b/src/components/Startup/StartupList.module.css
@@ -1,0 +1,49 @@
+.table {
+  width: 100%;
+
+  margin-top: 1.6rem;
+  border-radius: 0.25rem;
+
+  overflow: hidden;
+}
+
+.table tr:hover {
+  background-color: var(--secondary-black-200);
+  /* 부드러운 전환 효과 추가 */
+  transition: background-color 0.3s ease;
+}
+
+.table th,
+.table td {
+  padding: 1rem;
+
+  font-size: 1.4rem;
+  line-height: 1.7rem;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.table thead {
+  border-bottom: 1.6rem solid var(--secondary-black-400);
+
+  background-color: var(--secondary-black-100);
+  color: white;
+  font-weight: 500;
+}
+
+.table tbody {
+  background-color: var(--secondary-black-300);
+  font-weight: 400;
+}
+
+.table tbody td {
+  height: 6.4rem;
+}
+
+.table tbody td:nth-child(2) {
+  font-weight: 500;
+}
+
+.table tbody tr:not(:last-child) {
+  border-bottom: 0.1rem solid var(--secondary-gray-300);
+}

--- a/src/hooks/useFetchStartups.js
+++ b/src/hooks/useFetchStartups.js
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { getStartupList } from "../api/StartupService";
+
+const useFetchStartups = (initialPage = 1, maxItems = 10, initialOrder = 'total_investment', initialSort = 'desc') => {
+  const [startups, setStartups] = useState([]);
+  const [error, setError] = useState(null);
+  const [order, setOrder] = useState(initialOrder);
+  const [sort, setSort] = useState(initialSort);
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const [totalCount, setTotalCount] = useState(0);
+
+  const [search, setSearch] = useState('');
+  const [showLoading, setShowLoading] = useState(false);  // 로딩 화면을 표시할지 여부
+
+  const MIN_LOADING_TIME = 500; // 최소 로딩 시간, 로딩 화면이 짧게 깜빡이는 것을 방지
+
+  useEffect(() => {
+    const fetchStartups = async () => {
+      const loadingTimer = setTimeout(() => {
+        setShowLoading(true);  // 최소 로딩시간이 지나면 로딩 화면 표시
+      }, MIN_LOADING_TIME);
+      
+      try {
+        const startupList = await getStartupList(currentPage, maxItems, order, sort, search);
+        console.log('startupList', startupList);
+        setStartups(startupList.list || []);
+        setTotalCount(startupList.totoalCount || 0);
+      } catch (e) {
+        console.log(e.message);
+        setError('스타트업 정보를 불러오는 데 실패하였습니다');
+      } finally {
+        clearTimeout(loadingTimer);
+        setShowLoading(false);
+      }
+    };
+    fetchStartups();
+  }, [currentPage, maxItems, order, sort, search]);
+
+  return {
+    startups,
+    error,
+    order,
+    setOrder,
+    sort,
+    setSort,
+    currentPage,
+    setCurrentPage,
+    totoalCount: totalCount,
+    setSearch,
+    showLoading,
+  };
+};
+
+export default useFetchStartups;

--- a/src/pages/StartupPage.js
+++ b/src/pages/StartupPage.js
@@ -1,3 +1,12 @@
+
+import StartupHeader from "../components/Startup/StartupHeader";
+import StartupList from "../components/Startup/StartupList";
+
 export default function StartupPage() {
-  return;
+  return (
+    <div>
+      <StartupHeader />
+      <StartupList />
+    </div>
+  )
 }


### PR DESCRIPTION
### 전체 스타트업 목록 화면 구현
* 백엔드 API 연동을 통해 스타트업 목록 데이터 불러오기
* 스타트업 목록을 테이블 구조로 표시
* 기업명 옆에 로고 표시 및 이미지와 텍스트의 세로 가운데 정렬 처리
* 테이블 스타일링 추가 (말줄임표 처리, 스크롤 및 테이블 레이아웃 조정)

아직 작업이 완료 되지 않았는데, 혹시 테이블 컨트롤하는데 힌트가 될까 싶어서 미리 PR 올립니다.

좀 편하게 복붙?해서 쓰게 만드려고 했는데, 쉽지 않네요.
일단, 참고만 해주세요.


![2024-10-02 00 38 24](https://github.com/user-attachments/assets/dbcf86b3-475d-4e36-b79f-0d951bb03903)
