### PR TITLE
[김은효] Fix: 드롭다운(.table overflow: visible) 설정

### DIFF
--- a/src/components/StartupDetail/StartupDetailInvest.module.css
+++ b/src/components/StartupDetail/StartupDetailInvest.module.css
@@ -37,7 +37,7 @@
   background-color: var(--primary-orange);
 }
 
-.content> :nth-child(2) h1 {
+.content > :nth-child(2) h1 {
   padding: 1.6rem 0;
   border-top: 0.1rem solid var(--secondary-black-100);
 
@@ -52,12 +52,13 @@
   min-width: 80rem;
   border-radius: 0.4rem;
 
-  overflow: hidden;
+  overflow: visible;
   position: relative;
 }
 
 .wrapper {
   overflow-x: auto;
+  border-radius: 0.4rem;
   padding-bottom: 1.2rem;
 }
 
@@ -115,12 +116,10 @@
   font-weight: 400;
   line-height: 1.671rem;
   text-align: center;
-
 }
 
 /***** Tablet *****/
 @media (max-width: 1199px) and (min-width: 744px) {
-
   /* 전체 스크롤바 */
   .wrapper::-webkit-scrollbar {
     width: 100%;
@@ -155,7 +154,7 @@
     line-height: 1.671rem;
   }
 
-  .content> :nth-child(2) h1 {
+  .content > :nth-child(2) h1 {
     font-size: 1.6rem;
     line-height: 1.909rem;
   }


### PR DESCRIPTION
## 드롭다운 메뉴 잘림 현상 수정 ##

투자자 목록 마지막 부분의 더보기를 누를 때 드롭다운 메뉴일부가 보이지 않는 현상을 수정하였습니다. ( line 55)

이외의 부분은 저장 설정이 다르게 되어있어 띄어쓰기 등이 변경되었습니다.

아직 테이블 하단의 border-radius는 구현하지 못했으나 된 부분까지만 우선 커밋합니다.

이전에 올렸던 PR은 Close 해두겠습니다.