### PR TITLE
[소재희] conditionally apply inline styles to Pagination component

### DIFF
--- a/src/components/Common/Pagination.js
+++ b/src/components/Common/Pagination.js
@@ -8,9 +8,9 @@ const Pagination = ({
   currentPage, 
   totalPages, 
   onPageChange, 
-  pageButtonSize = '4.8rem', 
-  pageButtonBorderRadius='1rem', 
-  pageButtonFontSize='1.8rem' 
+  pageButtonSize,
+  pageButtonBorderRadius,
+  pageButtonFontSize
 }) => {
 
   if (totalPages <= 1) {
@@ -46,18 +46,30 @@ const Pagination = ({
     }
   };
 
+  // 인라인 스타일을 조건부로 설정
+  const buttonStyle = (size, borderRadius, fontSize) => {
+    // props가 전달된 경우에만 인라인 스타일을 적용
+    const style = {};
+    if (size) {
+      style.width = size;
+      style.height = size;
+    }
+    if (borderRadius) {
+      style.borderRadius = borderRadius;
+    }
+    if (fontSize) {
+      style.fontSize = fontSize;
+    }
+    return style;
+  };
+
   return (
     <div className={styles.pagination}>
       {startPage > 1 && (
         <button
           className={styles.paginationButton}
           onClick={handlePrevGroupClick}
-          style={{ 
-            width: pageButtonSize, 
-            height: pageButtonSize,
-            borderRadius: pageButtonBorderRadius,
-            fontSize: pageButtonFontSize
-          }}
+          style={buttonStyle(pageButtonSize, pageButtonBorderRadius, pageButtonFontSize)}
         >
           <img
             src={arrowLeftIcon}
@@ -73,12 +85,7 @@ const Pagination = ({
           onClick={() => {
             onPageChange(page);  // 페이지 변경
           }}
-          style={{ 
-            width: pageButtonSize, 
-            height: pageButtonSize,
-            borderRadius: pageButtonBorderRadius,
-            fontSize: pageButtonFontSize
-          }}
+          style={buttonStyle(pageButtonSize, pageButtonBorderRadius, pageButtonFontSize)}
         >
           {page}
         </button>
@@ -88,12 +95,7 @@ const Pagination = ({
         <button
           className={styles.paginationButton}
           onClick={handleNextGroupClick}
-          style={{ 
-            width: pageButtonSize, 
-            height: pageButtonSize,
-            borderRadius: pageButtonBorderRadius,
-            fontSize: pageButtonFontSize
-          }}
+          style={buttonStyle(pageButtonSize, pageButtonBorderRadius, pageButtonFontSize)}
         >
           <img
             src={arrowRightIcon}

--- a/src/components/Startup/StartupList.js
+++ b/src/components/Startup/StartupList.js
@@ -144,9 +144,9 @@ export default function StartupList() {
           currentPage={currentPage}
           totalPages={totalPages}
           onPageChange={handlePageChange}
-          pageButtonSize='4.8rem'
-          pageButtonBorderRadius='1rem'
-          pageButtonFontSize='1.8rem'
+          //pageButtonSize='4.8rem'
+          //pageButtonBorderRadius='1rem'
+          //pageButtonFontSize='1.8rem'
         />
       </div>
     </>


### PR DESCRIPTION
### 페이지네이션 스타일 적용
- pageButtonSize 등의 props가 전달되지 않을 경우 인라인 스타일을 적용하지 않음
- 기본 CSS와 미디어 쿼리가 적용되어 모바일 환경에서 버튼 크기 자동 조정
- props가 전달된 경우에는 인라인 스타일로 크기 지정하여 데스크탑과 모바일에서 동일한 크기 유지
  (팝업창에서는 모바일 환경에서의 버튼 사이즈가 동일하여, 이때만 사이즈 지정하시면 됩니다.)
- 인라인 스타일 우선순위로 인해 미디어 쿼리가 적용되지 않는 문제 해결