### PR TITLE
[서지우] fix: 비교현황 페이지 드롭다운 한줄로

### DIFF
--- a/src/components/ComparisonStatus/ComparisonDropdown.module.css
+++ b/src/components/ComparisonStatus/ComparisonDropdown.module.css
@@ -32,7 +32,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-/*  white-space: nowrap; */
+  white-space: nowrap;
 
   width: 100%;
 
@@ -77,7 +77,7 @@
 @media (max-width: 743px) {
   .menu {
     height: 4rem; 
-    max-width: 13.6rem;
+    max-width: 27rem;
     margin-right: 1rem;
     gap: 0.8rem;
     width: auto;


### PR DESCRIPTION
### 비교 현황 페이지 드롭다운 컨테이너 박스 크기 조절, 선택된 드롭다운 메뉴 한줄로 고정